### PR TITLE
Version 2.0.1

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Evan Darwin
+Copyright (c) 2015-2020 Evan Darwin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ A tiny PHP library that generates JSON responses based on the original [JSend sp
 
 The specification has been slightly modified to make use for APIs, in which the are now optional `code` and `message` attributes. Both are meant to be human readable, and will not show up if not supplied.
 
+> **Version 2.x requires PHP 7.2+**
+> If you need support for PHP >= 5.6, use the 1.x branch.
+
 ## Installation
 
 Install JSend via Composer:
@@ -22,13 +25,16 @@ You can use JSend like so:
 
 ```php
 <?php
-
 use EvanDarwin\JSend\JSendBuilder;
 
 $builder = new JSendBuilder();
 
 // This will return a JSendResponse
-$response = $builder->success()->data(['id' => 3])->code(12)->message("Hello")->get();
+$response = $builder->success()
+                    ->data(['id' => 3])
+                    ->code(12)
+                    ->message("Hello")
+                    ->get();
 
 // Output the JSON
 header('Content-Type: application/json');
@@ -54,13 +60,16 @@ Alternative statuses include:
 
 ```php
 <?php
+use EvanDarwin\JSend\JSendBuilder;
+
 // These alternatives statuses can be set like so
+$builder = new JSendBuilder();
 
 // For failure
-$builder->failed();
+$builder->failed()->get();
 
 // For error
-$builder->error();
+$builder->error()->get();
 ```
 
 ## License

--- a/src/JSendBuilder.php
+++ b/src/JSendBuilder.php
@@ -141,11 +141,11 @@ class JSendBuilder {
     /**
      * Returns the built object
      *
-     * @return JSendResponse
+     * @return JSendResponse|mixed
      *
      * @throws InvalidArgumentException
      */
-    public function get(): JSendResponse {
+    public function get() {
         return new JSendResponse($this->status, $this->data, $this->errors, $this->code, $this->message);
     }
 }


### PR DESCRIPTION
**Fixes:**
- Removed the strict return type on `JSendBuilder::get()` to allow for interfaces to implement their own custom types

**Other Stuff:**
- Updated README dates
- Updated LICENSE